### PR TITLE
add array spacing rule

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,5 +1,10 @@
 'use strict'
 
+const { always, error } = require('./constants')
+
 module.exports = {
-  extends: 'standard'
+  extends: 'standard',
+  rules: {
+    'array-bracket-spacing': [ error, always, { objectsInArrays: true, arraysInArrays: true } ]
+  }
 }


### PR DESCRIPTION
Add rule for:

https://eslint.org/docs/rules/array-bracket-spacing

Means that we declare arrays as such:

```js
const someArray = [ 'this', 'is', [ 'an', 'array' ], { of: 'things' } ]
```

This got turned off by accident, but prior, all the brackets and objects had spacing.

[![](https://api.gh-polls.com/poll/01EAC5WZ634EGYC92EMG3SVM5Z/Enforce%20%5Bno%2C%20array%2C%20spacing%5D)](https://api.gh-polls.com/poll/01EAC5WZ634EGYC92EMG3SVM5Z/Enforce%20%5Bno%2C%20array%2C%20spacing%5D/vote)
[![](https://api.gh-polls.com/poll/01EAC5WZ634EGYC92EMG3SVM5Z/Enforce%20%5B%20always%2C%20array%2C%20spacing%20%5D)](https://api.gh-polls.com/poll/01EAC5WZ634EGYC92EMG3SVM5Z/Enforce%20%5B%20always%2C%20array%2C%20spacing%20%5D/vote)