### PR TITLE
feat: Turn off svelte/require-each-key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beyonk/eslint-config",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Eslint config for beyonk",
   "main": "index.js",
   "scripts": {

--- a/svelte.js
+++ b/svelte.js
@@ -31,7 +31,7 @@ export default [
       }
     },
     rules: {
-      'svelte/require-each-key': warn,
+      'svelte/require-each-key': off,
       'svelte/no-at-html-tags': off
     }
   }

--- a/svelte.js
+++ b/svelte.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
 import svelte from 'eslint-plugin-svelte'
 import globals from 'globals'
-import { warn, off } from './constants.js'
+import { off } from './constants.js'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 


### PR DESCRIPTION
each keys in svelte are not required. The `key` is to tell svelte to recreate the DOM element entirely rather than reusing them. keys are only required when the element must be completely destroyed and recreated, like during an animation or to rerun actions.