### PR TITLE
feat(svelte): use svelte prefer const

### DIFF
--- a/svelte.js
+++ b/svelte.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
 import svelte from 'eslint-plugin-svelte'
 import globals from 'globals'
-import { off } from './constants.js'
+import { off, error } from './constants.js'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -32,7 +32,9 @@ export default [
     },
     rules: {
       'svelte/require-each-key': off,
-      'svelte/no-at-html-tags': off
+      'svelte/no-at-html-tags': off,
+      'prefer-const': off,
+      'svelte/prefer-const': error
     }
   }
 ]


### PR DESCRIPTION
Resolves prefer const for `let { propName } = $props()` declarations in Svelte 5 runes.

https://github.com/sveltejs/eslint-plugin-svelte/issues/818#issuecomment-2570986849